### PR TITLE
Repositories, Jobs, Resources, Services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+## 1.1
+
+- Generator for repositories, services, exceptions and job added
+- Fixed error with generating models with migrations `domain:make:model {domain} {name} -m`
+- Fixed problem with stub not found for _model_ when stubs weren't published
+- "routes" capitalized to "Routes" for consistency
+
+## 1.0
+
+Initial package upload

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,18 +2,13 @@
 
 Contributions are **welcome** and will be fully **credited**.
 
-We accept contributions via Pull Requests on [Github](https://github.com/phpSquad/domain-maker).
+We accept contributions via Pull Requests on [Github](https://github.com/phpsquad/domain-maker).
 
 
 ## Pull Requests
 
-- **[PSR-2 Coding Standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md)** - The easiest way to apply the conventions is to install [PHP Code Sniffer](http://pear.php.net/package/PHP_CodeSniffer).
 
-- **Add tests!** - Your patch won't be accepted if it doesn't have tests.
-
-- **Document any change in behaviour** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
-
-- **Consider our release cycle** - We try to follow [SemVer v2.0.0](http://semver.org/). Randomly breaking public APIs is not an option.
+- **Document any change in behavior** - Make sure the `README.md` and any other relevant documentation are kept up-to-date.
 
 - **Create feature branches** - Don't ask us to pull from your master branch.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "phpsquad/domain-maker",
-    "description": "A description for domain-maker.",
+    "description": "Domain Driven Design for Laravel made easy",
     "type": "package",
     "license": "MIT",
     "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -1,21 +1,71 @@
 # domain-maker
 
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-[![Travis](https://img.shields.io/travis/phpSquad/domain-maker.svg?style=flat-square)]()
-[![Total Downloads](https://img.shields.io/packagist/dt/phpSquad/domain-maker.svg?style=flat-square)](https://packagist.org/packages/phpSquad/domain-maker)
 
 ## Install
-`composer require phpSquad/domain-maker`
+```bash
+composer require phpsquad/domain-maker
+```
 
 ## Usage
-Write a few lines about the usage of this package.
+The package makes Domain Driven Development easier in Laravel. 
 
-## Testing
-Run the tests with:
+### All Domain Maker Commands are under the prefix domain.
 
-``` bash
-vendor/bin/phpunit
+```bash
+ domain:make:controller        Create a new controller class
+ domain:make:domain            Create a new Domain
+ domain:make:routes            Create a new routes for domain
+ ...
 ```
+
+### Create new Domain
+```bash
+php artisan domain:make:domain
+```
+If this is the first domain the Domains directory will be created under app/Domains along with the specified domain. 
+
+```Bash
+Domains
+├── Invoice
+│   ├── Http
+│   │   ├── Controllers
+│   │   │   └── InvoiceController.php
+│   │   ├── Middleware
+│   │   └── Requests
+│   ├── Models
+│   ├── Repositories
+│   └── routes
+│       └── Invoice.php
+└── Media
+    ├── Http
+    │   ├── Controllers
+    │   │   └── MediaController.php
+    │   ├── Middleware
+    │   └── Requests
+    ├── Models
+    ├── Repositories
+    └── routes
+        └── Media.php
+
+```
+
+
+### Routing
+A standard route file is created when you create a domain via the command. 
+>Routes are discovered automatically via the DomainRouteServiceProvider
+
+To create subsequent route files use:
+
+```bash
+domain:make:routes  <domain-name> <route-file-name>
+```
+For example, if I have a "Payments" domain, and I'd like to group my Stripe Routes I'd run the command like so:
+
+```bash
+domain:make:routes Payments Stripe
+```
+
 
 ## Changelog
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
@@ -25,8 +75,8 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Credits
 
-- [Richard Rohrig](https://github.com/phpSquad)
-- [All Contributors](https://github.com/phpSquad/domain-maker/contributors)
+- [Richard Rohrig](https://github.com/phpsquad)
+- [All Contributors](https://github.com/phpsquad/domain-maker/contributors)
 
 ## Security
 If you discover any security-related issues, please email rick@wambo.com instead of using the issue tracker.

--- a/readme.md
+++ b/readme.md
@@ -3,33 +3,33 @@
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 
 ## The Why
-Domain Driven Design helps us to organize our thoughts and to build apps using logical grouping of our code. 
 
-If you've ever worked on a large laravel project you know how that model directory can grow so large that your ability to find things becomes hampered. 
+Domain Driven Design helps us to organize our thoughts and to build apps using logical grouping of our code.
 
-I was inspired by this article https://freek.dev/1486-getting-started-with-domain-oriented-laravel from Freek at Spatie to refactor to Domains. 
-I love it! It makes it so much easier to focus on a specific issue without the need to traverse the entire code base. 
-If I'm working on Payments, I live in the payments Domain.  
+If you've ever worked on a large laravel project you know how that model directory can grow so large that your ability to find things becomes hampered.
+
+I was inspired by this article https://freek.dev/1486-getting-started-with-domain-oriented-laravel from Freek at Spatie to refactor to Domains.
+I love it! It makes it so much easier to focus on a specific issue without the need to traverse the entire code base.
+If I'm working on Payments, I live in the payments Domain.
 
 I soon realized refactoring to DDD is pretty straight forward, but the typically wonderful development experience I've grown used to with laravel
-left a bit to be desired. 
+left a bit to be desired.
 
 Also, what if I know my project is going to be large, and I want to get a head start and begin development using DDD?
 
-That's why this package exists. 
-
-
+That's why this package exists.
 
 ## How can Domain Maker help you?
-Domain Maker makes Domain Driven Development easier in Laravel by providing you with a set of commands to create the scaffolding and boilerplate 
-laravel normally provides but tailored to a Domain Oriented Structure. 
 
-* Helpful Commands to:
-  * Automatically scaffold a new Domain with the often needed directories and classes
-  * create controllers
-  * create route files
-* Automatic Routes discovery (no need to register routes in the RouteServiceProvider)
-*
+Domain Maker makes Domain Driven Development easier in Laravel by providing you with a set of commands to create the scaffolding and boilerplate
+laravel normally provides but tailored to a Domain Oriented Structure.
+
+- Helpful Commands to:
+  - Automatically scaffold a new Domain with the often needed directories and classes
+  - create controllers
+  - create route files
+- Automatic Routes discovery (no need to register routes in the RouteServiceProvider)
+-
 
 ### All Domain Maker Commands are under the prefix domain.
 
@@ -41,6 +41,7 @@ laravel normally provides but tailored to a Domain Oriented Structure.
 ```
 
 ## Install
+
 ```bash
 composer require phpsquad/domain-maker
 ```
@@ -48,66 +49,96 @@ composer require phpsquad/domain-maker
 ## Usage
 
 ### Create new Domain
+
 ```bash
 php artisan domain:make:domain
 ```
-If this is the first domain the Domains directory will be created under app/Domains along with the specified domain. 
+
+If this is the first domain the Domains directory will be created under app/Domains along with the specified domain.
 
 ```Bash
 Domains
 ├── Invoice
+│   ├── Exceptions
 │   ├── Http
 │   │   ├── Controllers
 │   │   │   └── InvoiceController.php
 │   │   ├── Middleware
 │   │   └── Requests
+│   │   └── Resources
+│   ├── Jobs
 │   ├── Models
 │   ├── Repositories
-│   └── routes
+│   └── Routes
 │       └── Invoice.php
+│   ├── Services
 └── Media
-    ├── Http
-    │   ├── Controllers
-    │   │   └── MediaController.php
-    │   ├── Middleware
-    │   └── Requests
-    ├── Models
-    ├── Repositories
-    └── routes
-        └── Media.php
+│   ├── Exceptions
+│   ├── Http
+│   │   ├── Controllers
+│   │   │   └── InvoiceController.php
+│   │   ├── Middleware
+│   │   └── Requests
+│   │   └── Resources
+│   ├── Jobs
+│   ├── Models
+│   ├── Repositories
+|   └── Routes
+|       └── Media.php
+│   ├── Services
 
 ```
 
-
 ### Routing
-A standard route file is created when you create a domain via the `domain:make:domain` command. 
->Routes are discovered automatically via the DomainRouteServiceProvider
+
+A standard route file is created when you create a domain via the `domain:make:domain` command.
+
+> Routes are discovered automatically via the DomainRouteServiceProvider
 
 To create subsequent route files use:
 
 ```bash
 domain:make:routes  <domain-name> <route-file-name>
 ```
+
 For example, if I have a "Payments" domain, and I'd like to group my Stripe Routes I'd run the command like so:
 
 ```bash
 domain:make:routes Payments Stripe
 ```
 
+### Repositories
+
+A repository with standard CRUDs can easily be generate by using the `domain:make:repository`.
+
+```bash
+domain:make:repository <domain-name> <repository-name> <model-name>
+```
+
+Using the "Payments" domain again to demonstrate, we can use the command as follows:
+
+```bash
+domain:make:repository Payments PaymentRepository Payment
+```
+
 ### Stubs
-Public stubs will be used as a default. If stubs are unpublished, backups are contained in the package. 
+
+Public stubs will be used as a default. If stubs are unpublished, backups are contained in the package.
 
 There are package specific stubs that you may publish to override (i.e., routes.stub)
 
-> If you don't need to make changes to the stubs it's not necessary to publish them. 
+> If you don't need to make changes to the stubs it's not necessary to publish them.
+
 ```bash
 php artisan vendor:publish --tag=domain-stubs
 ```
 
 ## Changelog
+
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.
 
 ## Contributing
+
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 
 ## Credits
@@ -116,7 +147,9 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 - [All Contributors](https://github.com/phpsquad/domain-maker/contributors)
 
 ## Security
+
 If you discover any security-related issues, please email rick@wambo.com instead of using the issue tracker.
 
 ## License
+
 The MIT License (MIT). Please see [License File](/LICENSE.md) for more information.

--- a/readme.md
+++ b/readme.md
@@ -66,6 +66,15 @@ For example, if I have a "Payments" domain, and I'd like to group my Stripe Rout
 domain:make:routes Payments Stripe
 ```
 
+### Stubs
+Public stubs will be used as a default. If stubs are unpublished, backups are contained in the package. 
+
+There are package specific stubs that you may publish to override (i.e., routes.stub)
+
+> If you don't need to make changes to the stubs it's not necessary to publish them. 
+```bash
+php artisan vendor:publish --tag=domain-stubs
+```
 
 ## Changelog
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.

--- a/readme.md
+++ b/readme.md
@@ -1,14 +1,35 @@
-# domain-maker
+# Domain Maker for Laravel
 
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 
-## Install
-```bash
-composer require phpsquad/domain-maker
-```
+## The Why
+Domain Driven Design helps us to organize our thoughts and to build apps using logically grouping of our code. 
 
-## Usage
-The package makes Domain Driven Development easier in Laravel. 
+If you've ever worked on a large laravel project you know how that model directory can grow so large that your ability to find things becomes hampered. 
+
+I was inspired by this article https://freek.dev/1486-getting-started-with-domain-oriented-laravel from Freek at Spatie to refactor to Domains. 
+I love it! It makes it so much easier to focus on a specific issue without the need to traverse the entire code base. 
+If I'm working on Payment, I live in the payments Domain.  
+
+I soon realized refactoring to DDD is pretty straight forward, but the typically wonderful development experience I've grown used to with laravel
+left a bit to be desired. 
+
+Also, what if I know my project is going to be large, and I want to get a head start and being my development using DDD?
+
+That's why this package exists. 
+
+
+
+## How can Domain Maker help you?
+Domain Maker makes Domain Driven Development easier in Laravel by providing you with a set of commands to create the scaffolding and boilerplate 
+laravel normally provides but tailored to a Domain Oriented Structure. 
+
+* Helpful Commands to:
+  * Automatically scaffold a new Domain with the often needed directories and classes
+  * create controllers
+  * create route files
+* Automatic Routes discovery (no need to register routes in the RouteServiceProvider)
+*
 
 ### All Domain Maker Commands are under the prefix domain.
 
@@ -18,6 +39,13 @@ The package makes Domain Driven Development easier in Laravel.
  domain:make:routes            Create a new routes for domain
  ...
 ```
+
+## Install
+```bash
+composer require phpsquad/domain-maker
+```
+
+## Usage
 
 ### Create new Domain
 ```bash
@@ -52,7 +80,7 @@ Domains
 
 
 ### Routing
-A standard route file is created when you create a domain via the command. 
+A standard route file is created when you create a domain via the `domain:make:domain` command. 
 >Routes are discovered automatically via the DomainRouteServiceProvider
 
 To create subsequent route files use:

--- a/readme.md
+++ b/readme.md
@@ -3,18 +3,18 @@
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
 
 ## The Why
-Domain Driven Design helps us to organize our thoughts and to build apps using logically grouping of our code. 
+Domain Driven Design helps us to organize our thoughts and to build apps using logical grouping of our code. 
 
 If you've ever worked on a large laravel project you know how that model directory can grow so large that your ability to find things becomes hampered. 
 
 I was inspired by this article https://freek.dev/1486-getting-started-with-domain-oriented-laravel from Freek at Spatie to refactor to Domains. 
 I love it! It makes it so much easier to focus on a specific issue without the need to traverse the entire code base. 
-If I'm working on Payment, I live in the payments Domain.  
+If I'm working on Payments, I live in the payments Domain.  
 
 I soon realized refactoring to DDD is pretty straight forward, but the typically wonderful development experience I've grown used to with laravel
 left a bit to be desired. 
 
-Also, what if I know my project is going to be large, and I want to get a head start and being my development using DDD?
+Also, what if I know my project is going to be large, and I want to get a head start and begin development using DDD?
 
 That's why this package exists. 
 

--- a/src/Console/DomainControllerMakeCommand.php
+++ b/src/Console/DomainControllerMakeCommand.php
@@ -34,7 +34,7 @@ class DomainControllerMakeCommand extends GeneratorCommand
      */
     protected $type = 'Controller';
 
-    protected $domain = '';
+    protected $domain;
 
     /**
      * Get the stub file for the generator.
@@ -273,14 +273,16 @@ class DomainControllerMakeCommand extends GeneratorCommand
     {
         $storeRequestClass = 'Store'.class_basename($modelClass).'Request';
 
-        $this->call('make:request', [
+        $this->call('domain:make:request', [
             'name' => $storeRequestClass,
+            'domain' => $this->domain
         ]);
 
         $updateRequestClass = 'Update'.class_basename($modelClass).'Request';
 
-        $this->call('make:request', [
+        $this->call('domain:make:request', [
             'name' => $updateRequestClass,
+            'domain' => $this->domain
         ]);
 
         return [$storeRequestClass, $updateRequestClass];

--- a/src/Console/DomainControllerMakeCommand.php
+++ b/src/Console/DomainControllerMakeCommand.php
@@ -74,9 +74,11 @@ class DomainControllerMakeCommand extends GeneratorCommand
      */
     protected function resolveStubPath($stub)
     {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-            ? $customPath
-            : __DIR__.$stub;
+        $localPath = __DIR__ . '/..'. $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
     }
 
     /**

--- a/src/Console/DomainControllerMakeCommand.php
+++ b/src/Console/DomainControllerMakeCommand.php
@@ -34,6 +34,8 @@ class DomainControllerMakeCommand extends GeneratorCommand
      */
     protected $type = 'Controller';
 
+    protected $domain = '';
+
     /**
      * Get the stub file for the generator.
      *
@@ -89,10 +91,29 @@ class DomainControllerMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        $domainName = Str::studly($this->argument('domain'));
-        $path = $rootNamespace . '\Domains\\' . $domainName. '\Http\Controllers';
+        $this->domain = Str::studly($this->argument('domain'));
+        $path = $rootNamespace . '\Domains\\' . $this->domain . '\Http\Controllers';
         return $path;
     }
+
+    protected function getDefaultModelNamespace($rootNamespace)
+    {
+        $this->domain = Str::studly($this->argument('domain'));
+        $path = $rootNamespace . 'Domains\\' . $this->domain . '\Models';
+        return $path;
+    }
+
+    protected function qualifyModel(string $model)
+    {
+        $model = ltrim($model, '\\/');
+
+        $model = str_replace('/', '\\', $model);
+
+        $rootNamespace = $this->rootNamespace();
+
+        return $this->getDefaultModelNamespace($rootNamespace) . '\\' . $model;
+    }
+
 
     /**
      * Build the class with the given name.
@@ -134,7 +155,7 @@ class DomainControllerMakeCommand extends GeneratorCommand
 
         if (! class_exists($parentModelClass)) {
             if ($this->confirm("A {$parentModelClass} model does not exist. Do you want to generate it?", true)) {
-                $this->call('make:model', ['name' => $parentModelClass]);
+                $this->call('domain:make:model', ['name' => $parentModelClass]);
             }
         }
 
@@ -163,7 +184,7 @@ class DomainControllerMakeCommand extends GeneratorCommand
 
         if (! class_exists($modelClass)) {
             if ($this->confirm("A {$modelClass} model does not exist. Do you want to generate it?", true)) {
-                $this->call('make:model', ['name' => $modelClass]);
+                $this->call('domain:make:model', ['domain' => $this->domain, 'name' => $modelClass]);
             }
         }
 

--- a/src/Console/DomainControllerMakeCommand.php
+++ b/src/Console/DomainControllerMakeCommand.php
@@ -59,7 +59,7 @@ class DomainControllerMakeCommand extends GeneratorCommand
 
         if ($this->option('api') && is_null($stub)) {
             $stub = '/stubs/controller.api.stub';
-        } elseif ($this->option('api') && ! is_null($stub) && ! $this->option('invokable')) {
+        } elseif ($this->option('api') && !is_null($stub) && !$this->option('invokable')) {
             $stub = str_replace('.stub', '.api.stub', $stub);
         }
 
@@ -76,7 +76,7 @@ class DomainControllerMakeCommand extends GeneratorCommand
      */
     protected function resolveStubPath($stub)
     {
-        $localPath = __DIR__ . '/..'. $stub;
+        $localPath = __DIR__ . '/..' . $stub;
         $publishedPath = $this->laravel->basePath(trim($stub, '/'));
         return file_exists($publishedPath)
             ? $publishedPath
@@ -140,7 +140,9 @@ class DomainControllerMakeCommand extends GeneratorCommand
         $replace["use {$controllerNamespace}\Controller;\n"] = '';
 
         return str_replace(
-            array_keys($replace), array_values($replace), parent::buildClass($name)
+            array_keys($replace),
+            array_values($replace),
+            parent::buildClass($name)
         );
     }
 
@@ -153,7 +155,7 @@ class DomainControllerMakeCommand extends GeneratorCommand
     {
         $parentModelClass = $this->parseModel($this->option('parent'));
 
-        if (! class_exists($parentModelClass)) {
+        if (!class_exists($parentModelClass)) {
             if ($this->confirm("A {$parentModelClass} model does not exist. Do you want to generate it?", true)) {
                 $this->call('domain:make:model', ['name' => $parentModelClass]);
             }
@@ -182,7 +184,7 @@ class DomainControllerMakeCommand extends GeneratorCommand
     {
         $modelClass = $this->parseModel($this->option('model'));
 
-        if (! class_exists($modelClass)) {
+        if (!class_exists($modelClass)) {
             if ($this->confirm("A {$modelClass} model does not exist. Do you want to generate it?", true)) {
                 $this->call('domain:make:model', ['domain' => $this->domain, 'name' => $modelClass]);
             }
@@ -237,14 +239,16 @@ class DomainControllerMakeCommand extends GeneratorCommand
             $namespace = 'App\\Http\\Requests';
 
             [$storeRequestClass, $updateRequestClass] = $this->generateFormRequests(
-                $modelClass, $storeRequestClass, $updateRequestClass
+                $modelClass,
+                $storeRequestClass,
+                $updateRequestClass
             );
         }
 
-        $namespacedRequests = $namespace.'\\'.$storeRequestClass.';';
+        $namespacedRequests = $namespace . '\\' . $storeRequestClass . ';';
 
         if ($storeRequestClass !== $updateRequestClass) {
-            $namespacedRequests .= PHP_EOL.'use '.$namespace.'\\'.$updateRequestClass.';';
+            $namespacedRequests .= PHP_EOL . 'use ' . $namespace . '\\' . $updateRequestClass . ';';
         }
 
         return array_merge($replace, [
@@ -252,10 +256,10 @@ class DomainControllerMakeCommand extends GeneratorCommand
             '{{storeRequest}}' => $storeRequestClass,
             '{{ updateRequest }}' => $updateRequestClass,
             '{{updateRequest}}' => $updateRequestClass,
-            '{{ namespacedStoreRequest }}' => $namespace.'\\'.$storeRequestClass,
-            '{{namespacedStoreRequest}}' => $namespace.'\\'.$storeRequestClass,
-            '{{ namespacedUpdateRequest }}' => $namespace.'\\'.$updateRequestClass,
-            '{{namespacedUpdateRequest}}' => $namespace.'\\'.$updateRequestClass,
+            '{{ namespacedStoreRequest }}' => $namespace . '\\' . $storeRequestClass,
+            '{{namespacedStoreRequest}}' => $namespace . '\\' . $storeRequestClass,
+            '{{ namespacedUpdateRequest }}' => $namespace . '\\' . $updateRequestClass,
+            '{{namespacedUpdateRequest}}' => $namespace . '\\' . $updateRequestClass,
             '{{ namespacedRequests }}' => $namespacedRequests,
             '{{namespacedRequests}}' => $namespacedRequests,
         ]);
@@ -271,14 +275,14 @@ class DomainControllerMakeCommand extends GeneratorCommand
      */
     protected function generateFormRequests($modelClass, $storeRequestClass, $updateRequestClass)
     {
-        $storeRequestClass = 'Store'.class_basename($modelClass).'Request';
+        $storeRequestClass = 'Store' . class_basename($modelClass) . 'Request';
 
         $this->call('domain:make:request', [
             'name' => $storeRequestClass,
             'domain' => $this->domain
         ]);
 
-        $updateRequestClass = 'Update'.class_basename($modelClass).'Request';
+        $updateRequestClass = 'Update' . class_basename($modelClass) . 'Request';
 
         $this->call('domain:make:request', [
             'name' => $updateRequestClass,

--- a/src/Console/DomainExceptionMakeCommand.php
+++ b/src/Console/DomainExceptionMakeCommand.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace PhpSquad\DomainMaker\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Support\Str;
+
+
+
+/// Modified version of:
+/// https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Console/ExceptionMakeCommand.php
+class DomainExceptionMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'domain:make:exception';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new custom exception class for a domain';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Exception';
+
+    /**
+     * The domain to  create the exception in
+     *
+     * @var string
+     */
+    protected $domain;
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        if ($this->option('render')) {
+            return $this->option('report')
+                ? $this->resolveStubPath('/stubs/exception-render-report.stub')
+                : $this->resolveStubPath('/stubs/exception-render.stub');
+        }
+
+        return $this->option('report')
+            ? $this->resolveStubPath('/stubs/exception-report.stub')
+            : $this->resolveStubPath('/stubs/exception.stub');
+    }
+
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        $localPath = __DIR__ . '/..' . $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
+    }
+
+    /**
+     * Determine if the class already exists.
+     *
+     * @param  string  $rawName
+     * @return bool
+     */
+    protected function alreadyExists($rawName)
+    {
+        return class_exists($this->rootNamespace() . 'Exceptions\\' . $rawName);
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        $this->domain = Str::studly($this->argument('domain'));
+        return $rootNamespace . '\Domains\\' . $this->domain . '\\Exceptions';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['render', null, InputOption::VALUE_NONE, 'Create the exception with an empty render method'],
+
+            ['report', null, InputOption::VALUE_NONE, 'Create the exception with an empty report method'],
+        ];
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['domain', InputArgument::REQUIRED, 'The domain of the class'],
+            ['name', InputArgument::REQUIRED, 'The name of the class'],
+        ];
+    }
+}

--- a/src/Console/DomainFactoryMakeCommand.php
+++ b/src/Console/DomainFactoryMakeCommand.php
@@ -46,9 +46,11 @@ class DomainFactoryMakeCommand extends DomainGeneratorCommand
      */
     protected function resolveStubPath($stub)
     {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-            ? $customPath
-            : __DIR__.$stub;
+        $localPath = __DIR__ . '/..' . $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
     }
 
     /**
@@ -62,13 +64,13 @@ class DomainFactoryMakeCommand extends DomainGeneratorCommand
         $factory = class_basename(Str::ucfirst(str_replace('Factory', '', $name)));
 
         $namespaceModel = $this->option('model')
-                        ? $this->qualifyModel($this->option('model'))
-                        : $this->qualifyModel($this->guessModelName($name));
+            ? $this->qualifyModel($this->option('model'))
+            : $this->qualifyModel($this->guessModelName($name));
 
         $model = class_basename($namespaceModel);
 
-        if (Str::startsWith($namespaceModel, $this->rootNamespace().'Models')) {
-            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, $this->rootNamespace().'Models\\'), '\\');
+        if (Str::startsWith($namespaceModel, $this->rootNamespace() . 'Models')) {
+            $namespace = Str::beforeLast('Database\\Factories\\' . Str::after($namespaceModel, $this->rootNamespace() . 'Models\\'), '\\');
         } else {
             $namespace = 'Database\\Factories';
         }
@@ -86,7 +88,9 @@ class DomainFactoryMakeCommand extends DomainGeneratorCommand
         ];
 
         return str_replace(
-            array_keys($replace), array_values($replace), parent::buildClass($name)
+            array_keys($replace),
+            array_values($replace),
+            parent::buildClass($name)
         );
     }
 
@@ -100,7 +104,7 @@ class DomainFactoryMakeCommand extends DomainGeneratorCommand
     {
         $name = (string) Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
 
-        return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
+        return $this->laravel->databasePath() . '/factories/' . str_replace('\\', '/', $name) . '.php';
     }
 
     /**
@@ -122,10 +126,10 @@ class DomainFactoryMakeCommand extends DomainGeneratorCommand
         }
 
         if (is_dir(app_path('Models/'))) {
-            return $this->rootNamespace().'Models\Model';
+            return $this->rootNamespace() . 'Models\Model';
         }
 
-        return $this->rootNamespace().'Model';
+        return $this->rootNamespace() . 'Model';
     }
 
     /**

--- a/src/Console/DomainFactoryMakeCommand.php
+++ b/src/Console/DomainFactoryMakeCommand.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace PhpSquad\DomainMaker\Console;
+
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
+
+class DomainFactoryMakeCommand extends DomainGeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'domain:make:factory';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new domain model factory';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Factory';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/factory.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__.$stub;
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $factory = class_basename(Str::ucfirst(str_replace('Factory', '', $name)));
+
+        $namespaceModel = $this->option('model')
+                        ? $this->qualifyModel($this->option('model'))
+                        : $this->qualifyModel($this->guessModelName($name));
+
+        $model = class_basename($namespaceModel);
+
+        if (Str::startsWith($namespaceModel, $this->rootNamespace().'Models')) {
+            $namespace = Str::beforeLast('Database\\Factories\\'.Str::after($namespaceModel, $this->rootNamespace().'Models\\'), '\\');
+        } else {
+            $namespace = 'Database\\Factories';
+        }
+
+        $replace = [
+            '{{ factoryNamespace }}' => $namespace,
+            'NamespacedDummyModel' => $namespaceModel,
+            '{{ namespacedModel }}' => $namespaceModel,
+            '{{namespacedModel}}' => $namespaceModel,
+            'DummyModel' => $model,
+            '{{ model }}' => $model,
+            '{{model}}' => $model,
+            '{{ factory }}' => $factory,
+            '{{factory}}' => $factory,
+        ];
+
+        return str_replace(
+            array_keys($replace), array_values($replace), parent::buildClass($name)
+        );
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = (string) Str::of($name)->replaceFirst($this->rootNamespace(), '')->finish('Factory');
+
+        return $this->laravel->databasePath().'/factories/'.str_replace('\\', '/', $name).'.php';
+    }
+
+    /**
+     * Guess the model name from the Factory name or return a default model name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function guessModelName($name)
+    {
+        if (Str::endsWith($name, 'Factory')) {
+            $name = substr($name, 0, -7);
+        }
+
+        $modelName = $this->qualifyModel(Str::after($name, $this->rootNamespace()));
+
+        if (class_exists($modelName)) {
+            return $modelName;
+        }
+
+        if (is_dir(app_path('Models/'))) {
+            return $this->rootNamespace().'Models\Model';
+        }
+
+        return $this->rootNamespace().'Model';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['model', 'm', InputOption::VALUE_OPTIONAL, 'The name of the model'],
+        ];
+    }
+}

--- a/src/Console/DomainGeneratorCommand.php
+++ b/src/Console/DomainGeneratorCommand.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace PhpSquad\DomainMaker\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputArgument;
+
+class DomainGeneratorCommand extends GeneratorCommand
+{
+
+    protected $domain;
+
+    protected function getStub()
+    {
+        // TODO: Implement getStub() method.
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['domain', InputArgument::REQUIRED, 'The domain of the class'],
+            ['name', InputArgument::REQUIRED, 'The name of the class'],
+        ];
+    }
+}

--- a/src/Console/DomainJobMakeCommand.php
+++ b/src/Console/DomainJobMakeCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace PhpSquad\DomainMaker\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Illuminate\Support\Str;
+
+/// Modified version of:
+/// https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Console/JobMakeCommand.php
+class DomainJobMakeCommand extends GeneratorCommand
+{
+    use CreatesMatchingTest;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'domain:make:job';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new job class';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Job';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->option('sync')
+            ? $this->resolveStubPath('/stubs/job.stub')
+            : $this->resolveStubPath('/stubs/job.queued.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        $localPath = __DIR__ . '/..' . $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
+    }
+
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        $this->domain = Str::studly($this->argument('domain'));
+        return $rootNamespace . '\Domains\\' . $this->domain . '\\Jobs';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['sync', null, InputOption::VALUE_NONE, 'Indicates that job should be synchronous'],
+        ];
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['domain', InputArgument::REQUIRED, 'The domain of the class'],
+            ['name', InputArgument::REQUIRED, 'The name of the class'],
+        ];
+    }
+}

--- a/src/Console/DomainMakeCommand.php
+++ b/src/Console/DomainMakeCommand.php
@@ -101,14 +101,14 @@ class DomainMakeCommand extends Command
         $routesOptions = $this->getRoutesOptions($domain, $wantsController);
 
         if ($wantsController) {
-            $controllerOptions = $this->getContollerOptions($domain, $wantsController);
+            $controllerOptions = $this->getControllerOptions($domain, $wantsController);
             $this->call('domain:make:controller', $controllerOptions);
         }
 
         $this->call('domain:make:routes', $routesOptions);
     }
 
-    protected function getContollerOptions(string $domain, $wantsController): array
+    protected function getControllerOptions(string $domain): array
     {
         return ['domain' => $domain, 'name' => "{$domain}Controller"];
     }

--- a/src/Console/DomainMakeCommand.php
+++ b/src/Console/DomainMakeCommand.php
@@ -4,24 +4,15 @@ namespace PhpSquad\DomainMaker\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class DomainMakeCommand extends Command
 {
-    /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'domain:make:domain {domain} {name?}';
-
-    /**
-     * The console command description.
-     *
-     * @var string
-     */
+    protected $name = 'domain:make:domain';
     protected $description = 'Command description';
-
-
+    protected $type = 'Route';
+    protected function getStub(){}
     public function handle(): int
     {
         try {
@@ -105,9 +96,44 @@ class DomainMakeCommand extends Command
     protected function createController()
     {
         $domain = Str::studly(class_basename($this->argument('domain')));
-        $name = !empty($this->argument('name')) ? Str::studly(class_basename($this->argument('name'))) : $domain;
+        $wantsController = $this->option('controller');
 
-        $this->call('domain:make:controller', ['domain' => $domain, 'name' => "{$domain}Controller"]);
-        $this->call('domain:make:routes', ['domain' => $domain, 'name' => $name]);
+        $routesOptions = $this->getRoutesOptions($domain, $wantsController);
+
+        if ($wantsController) {
+            $controllerOptions = $this->getContollerOptions($domain, $wantsController);
+            $this->call('domain:make:controller', $controllerOptions);
+        }
+
+        $this->call('domain:make:routes', $routesOptions);
+    }
+
+    protected function getContollerOptions(string $domain, $wantsController): array
+    {
+        return ['domain' => $domain, 'name' => "{$domain}Controller"];
+    }
+
+    protected function getRoutesOptions(string $domain, $wantsController): array
+    {
+        if ($wantsController){
+
+            return ['domain' => $domain, 'name' => $domain, "--controller" => "{$domain}Controller"];
+        }
+
+        return ['domain' => $domain, 'name' => $domain];
+    }
+
+    protected function getOptions()
+    {
+        return [
+            ['controller', 'c', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class.'],
+        ];
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['domain', InputArgument::REQUIRED, 'name of domain.'],
+        ];
     }
 }

--- a/src/Console/DomainMakeCommand.php
+++ b/src/Console/DomainMakeCommand.php
@@ -12,7 +12,9 @@ class DomainMakeCommand extends Command
     protected $name = 'domain:make:domain';
     protected $description = 'Command description';
     protected $type = 'Route';
-    protected function getStub(){}
+    protected function getStub()
+    {
+    }
     public function handle(): int
     {
         try {
@@ -37,12 +39,12 @@ class DomainMakeCommand extends Command
 
             $appDirExists = file_exists($appDir);
 
-            if ($appDirExists){
+            if ($appDirExists) {
                 break;
             }
         }
 
-        if (!$appDirExists){
+        if (!$appDirExists) {
             throw new \Exception('Could not find app directory! Command must be with in subdirectory of app');
         }
 
@@ -56,7 +58,7 @@ class DomainMakeCommand extends Command
         $domainDir = $appDir . '/Domains';
         $domainDirExists = file_exists($domainDir);
 
-        if (!$domainDirExists){
+        if (!$domainDirExists) {
             mkdir($domainDir);
         }
 
@@ -68,22 +70,26 @@ class DomainMakeCommand extends Command
         $newDomainDir = $domainsDir . '/' . $domain;
         $alreadyExists = file_exists($newDomainDir);
 
-        if ($alreadyExists){
+        if ($alreadyExists) {
             throw new \Exception($domain . ' domain already exists! Will not overwrite existing domain.');
         }
 
         mkdir($newDomainDir);
 
         $folders = [
-            'Repositories',
-            'Models',
-            'routes',
             'Http/Controllers',
             'Http/Middleware',
-            'Http/Requests'
+            'Http/Requests',
+            'Http/Resources',
+            'Repositories',
+            'Models',
+            'Routes',
+            'Exceptions',
+            'Jobs',
+            'Services',
         ];
 
-        foreach($folders as $folder){
+        foreach ($folders as $folder) {
             $newFolder = $newDomainDir . '/' . $folder;
             mkdir($newFolder, 0777, true);
         }
@@ -115,7 +121,7 @@ class DomainMakeCommand extends Command
 
     protected function getRoutesOptions(string $domain, $wantsController): array
     {
-        if ($wantsController){
+        if ($wantsController) {
 
             return ['domain' => $domain, 'name' => $domain, "--controller" => "{$domain}Controller"];
         }

--- a/src/Console/DomainModelMakeCommand.php
+++ b/src/Console/DomainModelMakeCommand.php
@@ -62,7 +62,7 @@ class DomainModelMakeCommand extends GeneratorCommand
     {
         $factory = Str::studly($this->argument('name'));
 
-        $this->call('make:factory', [
+        $this->call('domain:make:factory', [
             'name' => "{$factory}Factory",
             '--model' => $this->qualifyClass($this->getNameInput()),
         ]);
@@ -81,7 +81,7 @@ class DomainModelMakeCommand extends GeneratorCommand
             $table = Str::singular($table);
         }
 
-        $this->call('make:migration', [
+        $this->call('domain:make:migration', [
             'name' => "create_{$table}_table",
             '--create' => $table,
         ]);
@@ -96,7 +96,7 @@ class DomainModelMakeCommand extends GeneratorCommand
     {
         $seeder = Str::studly(class_basename($this->argument('name')));
 
-        $this->call('make:seeder', [
+        $this->call('domain:make:seeder', [
             'name' => "{$seeder}Seeder",
         ]);
     }
@@ -130,7 +130,7 @@ class DomainModelMakeCommand extends GeneratorCommand
     {
         $policy = Str::studly(class_basename($this->argument('name')));
 
-        $this->call('make:policy', [
+        $this->call('domain:make:policy', [
             'name' => "{$policy}Policy",
             '--model' => $this->qualifyClass($this->getNameInput()),
         ]);

--- a/src/Console/DomainModelMakeCommand.php
+++ b/src/Console/DomainModelMakeCommand.php
@@ -15,6 +15,7 @@ class DomainModelMakeCommand extends GeneratorCommand
     protected $name = 'domain:make:model';
     protected $description = 'Create a new Domain Eloquent model class';
     protected $type = 'Model';
+    protected $domain;
 
     public function handle()
     {
@@ -111,8 +112,9 @@ class DomainModelMakeCommand extends GeneratorCommand
 
         $modelName = $this->qualifyClass($this->getNameInput());
 
-        $this->call('make:controller', array_filter([
+        $this->call('domain:make:controller', array_filter([
             'name' => "{$controller}Controller",
+            'domain' => $this->domain,
             '--model' => $this->option('resource') || $this->option('api') ? $modelName : null,
             '--api' => $this->option('api'),
             '--requests' => $this->option('requests') || $this->option('all'),
@@ -167,8 +169,8 @@ class DomainModelMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        $domainName = Str::studly($this->argument('domain'));
-        return $rootNamespace . '\Domains\\' . $domainName.'\\Models';
+        $this->domain = Str::studly($this->argument('domain'));
+        return $rootNamespace . '\Domains\\' . $this->domain.'\\Models';
     }
 
     protected function qualifyModel(string $model)

--- a/src/Console/DomainModelMakeCommand.php
+++ b/src/Console/DomainModelMakeCommand.php
@@ -81,7 +81,7 @@ class DomainModelMakeCommand extends GeneratorCommand
             $table = Str::singular($table);
         }
 
-        $this->call('domain:make:migration', [
+        $this->call('make:migration', [
             'name' => "create_{$table}_table",
             '--create' => $table,
         ]);
@@ -151,14 +151,16 @@ class DomainModelMakeCommand extends GeneratorCommand
     /**
      * Resolve the fully-qualified path to the stub.
      *
-     * @param string $stub
+     * @param  string  $stub
      * @return string
      */
     protected function resolveStubPath($stub)
     {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-            ? $customPath
-            : __DIR__ . $stub;
+        $localPath = __DIR__ . '/..' . $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
     }
 
     /**
@@ -170,7 +172,7 @@ class DomainModelMakeCommand extends GeneratorCommand
     protected function getDefaultNamespace($rootNamespace)
     {
         $this->domain = Str::studly($this->argument('domain'));
-        return $rootNamespace . '\Domains\\' . $this->domain.'\\Models';
+        return $rootNamespace . '\Domains\\' . $this->domain . '\\Models';
     }
 
     protected function qualifyModel(string $model)
@@ -188,8 +190,8 @@ class DomainModelMakeCommand extends GeneratorCommand
         }
 
         return is_dir(app_path('Models'))
-            ? $rootNamespace.'Models\\'.$model
-            : $rootNamespace.$model;
+            ? $rootNamespace . 'Models\\' . $model
+            : $rootNamespace . $model;
     }
 
     /**
@@ -222,4 +224,3 @@ class DomainModelMakeCommand extends GeneratorCommand
         ];
     }
 }
-

--- a/src/Console/DomainModelMakeCommand.php
+++ b/src/Console/DomainModelMakeCommand.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace PhpSquad\DomainMaker\Console;
+
+use Illuminate\Console\Concerns\CreatesMatchingTest;
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+
+class DomainModelMakeCommand extends GeneratorCommand
+{
+    use CreatesMatchingTest;
+
+    protected $name = 'domain:make:model';
+    protected $description = 'Create a new Domain Eloquent model class';
+    protected $type = 'Model';
+
+    public function handle()
+    {
+        if (parent::handle() === false && !$this->option('force')) {
+            return false;
+        }
+
+        if ($this->option('all')) {
+            $this->input->setOption('factory', true);
+            $this->input->setOption('seed', true);
+            $this->input->setOption('migration', true);
+            $this->input->setOption('controller', true);
+            $this->input->setOption('policy', true);
+            $this->input->setOption('resource', true);
+        }
+
+        if ($this->option('factory')) {
+            $this->createFactory();
+        }
+
+        if ($this->option('migration')) {
+            $this->createMigration();
+        }
+
+        if ($this->option('seed')) {
+            $this->createSeeder();
+        }
+
+        if ($this->option('controller') || $this->option('resource') || $this->option('api')) {
+            $this->createController();
+        }
+
+        if ($this->option('policy')) {
+            $this->createPolicy();
+        }
+    }
+
+    /**
+     * Create a model factory for the model.
+     *
+     * @return void
+     */
+    protected function createFactory()
+    {
+        $factory = Str::studly($this->argument('name'));
+
+        $this->call('make:factory', [
+            'name' => "{$factory}Factory",
+            '--model' => $this->qualifyClass($this->getNameInput()),
+        ]);
+    }
+
+    /**
+     * Create a migration file for the model.
+     *
+     * @return void
+     */
+    protected function createMigration()
+    {
+        $table = Str::snake(Str::pluralStudly(class_basename($this->argument('name'))));
+
+        if ($this->option('pivot')) {
+            $table = Str::singular($table);
+        }
+
+        $this->call('make:migration', [
+            'name' => "create_{$table}_table",
+            '--create' => $table,
+        ]);
+    }
+
+    /**
+     * Create a seeder file for the model.
+     *
+     * @return void
+     */
+    protected function createSeeder()
+    {
+        $seeder = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:seeder', [
+            'name' => "{$seeder}Seeder",
+        ]);
+    }
+
+    /**
+     * Create a controller for the model.
+     *
+     * @return void
+     */
+    protected function createController()
+    {
+        $controller = Str::studly(class_basename($this->argument('name')));
+
+        $modelName = $this->qualifyClass($this->getNameInput());
+
+        $this->call('make:controller', array_filter([
+            'name' => "{$controller}Controller",
+            '--model' => $this->option('resource') || $this->option('api') ? $modelName : null,
+            '--api' => $this->option('api'),
+            '--requests' => $this->option('requests') || $this->option('all'),
+        ]));
+    }
+
+    /**
+     * Create a policy file for the model.
+     *
+     * @return void
+     */
+    protected function createPolicy()
+    {
+        $policy = Str::studly(class_basename($this->argument('name')));
+
+        $this->call('make:policy', [
+            'name' => "{$policy}Policy",
+            '--model' => $this->qualifyClass($this->getNameInput()),
+        ]);
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->option('pivot')
+            ? $this->resolveStubPath('/stubs/model.pivot.stub')
+            : $this->resolveStubPath('/stubs/model.stub');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param string $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+            ? $customPath
+            : __DIR__ . $stub;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param string $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        $domainName = Str::studly($this->argument('domain'));
+        return $rootNamespace . '\Domains\\' . $domainName.'\\Models';
+    }
+
+    protected function qualifyModel(string $model)
+    {
+        $model = ltrim($model, '\\/');
+
+        $model = str_replace('/', '\\', $model);
+
+        $rootNamespace = $this->rootNamespace();
+
+        $defaultNamespace = $this->getDefaultNamespace($rootNamespace);
+
+        if (Str::startsWith($model, $rootNamespace)) {
+            return $model;
+        }
+
+        return is_dir(app_path('Models'))
+            ? $rootNamespace.'Models\\'.$model
+            : $rootNamespace.$model;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['all', 'a', InputOption::VALUE_NONE, 'Generate a migration, seeder, factory, policy, and resource controller for the model'],
+            ['controller', 'c', InputOption::VALUE_NONE, 'Create a new controller for the model'],
+            ['factory', 'f', InputOption::VALUE_NONE, 'Create a new factory for the model'],
+            ['force', null, InputOption::VALUE_NONE, 'Create the class even if the model already exists'],
+            ['migration', 'm', InputOption::VALUE_NONE, 'Create a new migration file for the model'],
+            ['policy', null, InputOption::VALUE_NONE, 'Create a new policy for the model'],
+            ['seed', 's', InputOption::VALUE_NONE, 'Create a new seeder for the model'],
+            ['pivot', 'p', InputOption::VALUE_NONE, 'Indicates if the generated model should be a custom intermediate table model'],
+            ['resource', 'r', InputOption::VALUE_NONE, 'Indicates if the generated controller should be a resource controller'],
+            ['api', null, InputOption::VALUE_NONE, 'Indicates if the generated controller should be an API controller'],
+            ['requests', 'R', InputOption::VALUE_NONE, 'Create new form request classes and use them in the resource controller'],
+        ];
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['domain', InputArgument::REQUIRED, 'The domain of the class'],
+            ['name', InputArgument::REQUIRED, 'The name of the class'],
+        ];
+    }
+}
+

--- a/src/Console/DomainRepositoryMakeCommand.php
+++ b/src/Console/DomainRepositoryMakeCommand.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace PhpSquad\DomainMaker\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+/// Modified version of:
+/// https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+class DomainRepositoryMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'domain:make:repository';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new repository for a domain';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Repository';
+    protected $domain;
+    protected $model;
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        $path = $this->getSourceFilePath();
+
+        $this->makeDirectory(dirname($path));
+
+        $contents = $this->getSourceFile();
+
+        if (!$this->files->exists($path)) {
+            $this->files->put($path, $contents);
+            $this->info("File : {$path} created");
+        } else {
+            $this->info("File : {$path} already exits");
+        }
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/repository.stub');
+    }
+
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        $localPath = __DIR__ . '/..' . $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @return string
+     */
+    protected function getTheNamespace()
+    {
+        $rootNamespace = $this->laravel->getNamespace();
+        $this->domain = Str::studly($this->argument('domain'));
+        return $rootNamespace . 'Domains\\' . $this->argument("domain") . '\Repositories';
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['domain', InputArgument::REQUIRED, 'The domain of the class'],
+            ['name', InputArgument::REQUIRED, 'The name of the class'],
+            ['model', InputArgument::REQUIRED, 'The model to generate a  repository for'],
+        ];
+    }
+
+    /**
+     * Get the full path of generate class
+     *
+     * @return string
+     */
+    public function getSourceFilePath()
+    {
+        $filename = $this->argument("name");
+        $domain = $this->argument("domain");
+        return base_path("App\\Domains\\$domain\\Repositories\\$filename.php");
+    }
+
+
+    /**
+     * Get the stub path and the stub variables
+     *
+     * @return bool|mixed|string
+     *
+     */
+    public function getSourceFile()
+    {
+
+        return $this->getStubContents($this->getStub(), $this->getStubVariables());
+    }
+
+    /**
+     * Replace the stub variables(key) with the desire value
+     *
+     * @param $stub
+     * @param array $stubVariables
+     * @return bool|mixed|string
+     */
+    public function getStubContents($stub, $stubVariables = [])
+    {
+        $contents = file_get_contents($stub);
+
+        foreach ($stubVariables as $search => $replace) {
+            $contents = str_replace($search, $replace, $contents);
+        }
+
+        return $contents;
+    }
+
+    /**
+     **
+     * Map the stub variables present in stub to its value
+     *
+     * @return array
+     *
+     */
+    public function getStubVariables()
+    {
+        return [
+            '{{ namespace }}' => $this->getTheNamespace(),
+            '{{ class }}'     => $this->argument('name'),
+            '{{ domain }}'    => $this->argument('domain'),
+            '{{ model }}'     => $this->argument('model')
+        ];
+    }
+}

--- a/src/Console/DomainRequestMakeCommand.php
+++ b/src/Console/DomainRequestMakeCommand.php
@@ -15,16 +15,24 @@ class DomainRequestMakeCommand extends DomainGeneratorCommand
         return $this->resolveStubPath('/stubs/request.stub');
     }
 
-    protected function resolveStubPath($stub): string
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
     {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-                        ? $customPath
-                        : __DIR__.$stub;
+        $localPath = __DIR__ . '/..' . $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
     }
 
     protected function getDefaultNamespace($rootNamespace): string
     {
         $this->domain = Str::studly($this->argument('domain'));
-        return $rootNamespace . '\Domains\\' . $this->domain.'\Http\Requests';
+        return $rootNamespace . '\Domains\\' . $this->domain . '\Http\Requests';
     }
 }

--- a/src/Console/DomainRequestMakeCommand.php
+++ b/src/Console/DomainRequestMakeCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace PhpSquad\DomainMaker\Console;
+
+use Illuminate\Support\Str;
+
+class DomainRequestMakeCommand extends DomainGeneratorCommand
+{
+    protected $name = 'domain:make:request';
+    protected $description = 'Create a new domain form request class';
+    protected $type = 'Request';
+
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/request.stub');
+    }
+
+    protected function resolveStubPath($stub): string
+    {
+        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
+                        ? $customPath
+                        : __DIR__.$stub;
+    }
+
+    protected function getDefaultNamespace($rootNamespace): string
+    {
+        $this->domain = Str::studly($this->argument('domain'));
+        return $rootNamespace . '\Domains\\' . $this->domain.'\Http\Requests';
+    }
+}

--- a/src/Console/DomainResourceMakeCommand.php
+++ b/src/Console/DomainResourceMakeCommand.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace PhpSquad\DomainMaker\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+/// Modified version of:
+/// https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+class DomainResourceMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'domain:make:resource';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new resource';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Resource';
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if ($this->collection()) {
+            $this->type = 'Resource collection';
+        }
+
+        parent::handle();
+    }
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->collection()
+            ? $this->resolveStubPath('/stubs/resource-collection.stub')
+            : $this->resolveStubPath('/stubs/resource.stub');
+    }
+
+    /**
+     * Determine if the command is generating a resource collection.
+     *
+     * @return bool
+     */
+    protected function collection()
+    {
+        return $this->option('collection') ||
+            Str::endsWith($this->argument('name'), 'Collection');
+    }
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        $localPath = __DIR__ . '/..' . $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        $this->domain = Str::studly($this->argument('domain'));
+        return $rootNamespace . '\Domains\\' . $this->domain . '\Http\Resources';
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['collection', 'c', InputOption::VALUE_NONE, 'Create a resource collection'],
+        ];
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['domain', InputArgument::REQUIRED, 'The domain of the class'],
+            ['name', InputArgument::REQUIRED, 'The name of the class'],
+        ];
+    }
+}

--- a/src/Console/DomainRouteMakeCommand.php
+++ b/src/Console/DomainRouteMakeCommand.php
@@ -78,7 +78,7 @@ class DomainRouteMakeCommand extends command
     {
         return [
             ['domain', InputArgument::REQUIRED, 'The domain of the class'],
-            ['name', InputArgument::OPTIONAL, 'The name of the class'],
+            ['name', InputArgument::REQUIRED, 'The name of the class'],
         ];
     }
 

--- a/src/Console/DomainRouteMakeCommand.php
+++ b/src/Console/DomainRouteMakeCommand.php
@@ -2,13 +2,13 @@
 
 namespace PhpSquad\DomainMaker\Console;
 
-use Illuminate\Console\GeneratorCommand as command;
+use Illuminate\Console\GeneratorCommand;
 use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 
-class DomainRouteMakeCommand extends command
+class DomainRouteMakeCommand extends GeneratorCommand
 {
     use CreatesMatchingTest;
 
@@ -20,7 +20,7 @@ class DomainRouteMakeCommand extends command
     {
         $stub = "/stubs/routes.stub";
 
-        if ($this->option('controller')){
+        if ($this->option('controller')) {
             $stub = "/stubs/routes-with-controller.stub";
         }
 
@@ -40,7 +40,7 @@ class DomainRouteMakeCommand extends command
     {
         $domain = $this->argument('domain');
 
-        return $rootNamespace . '\Domains\\' . $domain . '\routes';
+        return $rootNamespace . '\Domains\\' . $domain . '\Routes';
     }
 
     protected function buildClass($name)
@@ -59,7 +59,7 @@ class DomainRouteMakeCommand extends command
             $controller = $name . 'Controller';
         }
 
-        if ($wantsController){
+        if ($wantsController) {
             $controller = Str::studly($wantsController);
         }
 
@@ -70,7 +70,9 @@ class DomainRouteMakeCommand extends command
         ];
 
         return str_replace(
-            array_keys($replace), array_values($replace), parent::buildClass($name)
+            array_keys($replace),
+            array_values($replace),
+            parent::buildClass($name)
         );
     }
 

--- a/src/Console/DomainRouteMakeCommand.php
+++ b/src/Console/DomainRouteMakeCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand as command;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 class DomainRouteMakeCommand extends command
 {
@@ -18,6 +19,10 @@ class DomainRouteMakeCommand extends command
     protected function getStub(): string
     {
         $stub = "/stubs/routes.stub";
+
+        if ($this->option('controller')){
+            $stub = "/stubs/routes-with-controller.stub";
+        }
 
         return $this->resolveStubPath($stub);
     }
@@ -40,13 +45,13 @@ class DomainRouteMakeCommand extends command
 
     protected function buildClass($name)
     {
-
         $domain = $this->argument('domain');
         $prefix = Str::lower($domain);
         $domain = Str::studly($domain);
         $controller = $domain . 'Controller';
 
         $name = $this->argument('name');
+        $wantsController = $this->option('controller');
 
         if (!empty($name)) {
             $prefix = Str::lower($name);
@@ -54,6 +59,9 @@ class DomainRouteMakeCommand extends command
             $controller = $name . 'Controller';
         }
 
+        if ($wantsController){
+            $controller = Str::studly($wantsController);
+        }
 
         $replace = [
             '{{DummyPrefix}}' => $prefix,
@@ -71,6 +79,13 @@ class DomainRouteMakeCommand extends command
         return [
             ['domain', InputArgument::REQUIRED, 'The domain of the class'],
             ['name', InputArgument::OPTIONAL, 'The name of the class'],
+        ];
+    }
+
+    protected function getOptions()
+    {
+        return [
+            ['controller', 'c', InputOption::VALUE_OPTIONAL, 'Generate a nested resource controller class.'],
         ];
     }
 }

--- a/src/Console/DomainRouteMakeCommand.php
+++ b/src/Console/DomainRouteMakeCommand.php
@@ -2,8 +2,8 @@
 
 namespace PhpSquad\DomainMaker\Console;
 
-use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Console\GeneratorCommand as command;
+use Illuminate\Console\Concerns\CreatesMatchingTest;
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;

--- a/src/Console/DomainRouteMakeCommand.php
+++ b/src/Console/DomainRouteMakeCommand.php
@@ -24,9 +24,11 @@ class DomainRouteMakeCommand extends command
 
     protected function resolveStubPath($stub): string
     {
-        return file_exists($customPath = $this->laravel->basePath(trim($stub, '/')))
-            ? $customPath
-            : __DIR__ . $stub;
+        $localPath = __DIR__ . '/..' . $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
     }
 
     protected function getDefaultNamespace($rootNamespace): string

--- a/src/Console/DomainServiceMakeCommand.php
+++ b/src/Console/DomainServiceMakeCommand.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace PhpSquad\DomainMaker\Console;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+
+/// Modified version of:
+/// https://github.com/laravel/framework/blob/8.x/src/Illuminate/Foundation/Console/ResourceMakeCommand.php
+class DomainServiceMakeCommand extends GeneratorCommand
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'domain:make:service';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates a new service for a domain';
+
+    /**
+     * The type of class being generated.
+     *
+     * @var string
+     */
+    protected $type = 'Service';
+
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return $this->resolveStubPath('/stubs/service.stub');
+    }
+
+
+    /**
+     * Resolve the fully-qualified path to the stub.
+     *
+     * @param  string  $stub
+     * @return string
+     */
+    protected function resolveStubPath($stub)
+    {
+        $localPath = __DIR__ . '/..' . $stub;
+        $publishedPath = $this->laravel->basePath(trim($stub, '/'));
+        return file_exists($publishedPath)
+            ? $publishedPath
+            : $localPath;
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        $this->domain = Str::studly($this->argument('domain'));
+        return $rootNamespace . '\Domains\\' . $this->domain . '\Services';
+    }
+
+    protected function getArguments()
+    {
+        return [
+            ['domain', InputArgument::REQUIRED, 'The domain of the class'],
+            ['name', InputArgument::REQUIRED, 'The name of the class'],
+        ];
+    }
+}

--- a/src/DomainMakerServiceProvider.php
+++ b/src/DomainMakerServiceProvider.php
@@ -5,6 +5,7 @@ namespace PhpSquad\DomainMaker;
 use Illuminate\Support\ServiceProvider;
 use PhpSquad\DomainMaker\Console\DomainControllerMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainMakeCommand;
+use PhpSquad\DomainMaker\Console\DomainModelMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainRouteMakeCommand;
 
 
@@ -32,6 +33,7 @@ class DomainMakerServiceProvider extends ServiceProvider
                 DomainMakeCommand::class,
                 DomainControllerMakeCommand::class,
                 DomainRouteMakeCommand::class,
+                DomainModelMakeCommand::class
             ]);
         }
 

--- a/src/DomainMakerServiceProvider.php
+++ b/src/DomainMakerServiceProvider.php
@@ -34,5 +34,9 @@ class DomainMakerServiceProvider extends ServiceProvider
                 DomainRouteMakeCommand::class,
             ]);
         }
+
+        $this->publishes([
+            __DIR__.'/stubs/routes.stub' => base_path('stubs/routes.stub')
+        ], 'domain-stubs');
     }
 }

--- a/src/DomainMakerServiceProvider.php
+++ b/src/DomainMakerServiceProvider.php
@@ -2,14 +2,19 @@
 
 namespace PhpSquad\DomainMaker;
 
+use DomainException;
 use Illuminate\Support\ServiceProvider;
 use PhpSquad\DomainMaker\Console\DomainControllerMakeCommand;
+use PhpSquad\DomainMaker\Console\DomainExceptionMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainFactoryMakeCommand;
+use PhpSquad\DomainMaker\Console\DomainJobMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainModelMakeCommand;
+use PhpSquad\DomainMaker\Console\DomainRepositoryMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainRequestMakeCommand;
+use PhpSquad\DomainMaker\Console\DomainResourceMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainRouteMakeCommand;
-
+use PhpSquad\DomainMaker\Console\DomainServiceMakeCommand;
 
 class DomainMakerServiceProvider extends ServiceProvider
 {
@@ -37,12 +42,17 @@ class DomainMakerServiceProvider extends ServiceProvider
                 DomainRouteMakeCommand::class,
                 DomainModelMakeCommand::class,
                 DomainFactoryMakeCommand::class,
-                DomainRequestMakeCommand::class
+                DomainRequestMakeCommand::class,
+                DomainJobMakeCommand::class,
+                DomainResourceMakeCommand::class,
+                DomainExceptionMakeCommand::class,
+                DomainServiceMakeCommand::class,
+                DomainRepositoryMakeCommand::class,
             ]);
         }
 
         $this->publishes([
-            __DIR__.'/stubs/routes.stub' => base_path('stubs/routes.stub')
+            __DIR__ . '/stubs/routes.stub' => base_path('stubs/routes.stub')
         ], 'domain-stubs');
     }
 }

--- a/src/DomainMakerServiceProvider.php
+++ b/src/DomainMakerServiceProvider.php
@@ -4,8 +4,10 @@ namespace PhpSquad\DomainMaker;
 
 use Illuminate\Support\ServiceProvider;
 use PhpSquad\DomainMaker\Console\DomainControllerMakeCommand;
+use PhpSquad\DomainMaker\Console\DomainFactoryMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainModelMakeCommand;
+use PhpSquad\DomainMaker\Console\DomainRequestMakeCommand;
 use PhpSquad\DomainMaker\Console\DomainRouteMakeCommand;
 
 
@@ -33,7 +35,9 @@ class DomainMakerServiceProvider extends ServiceProvider
                 DomainMakeCommand::class,
                 DomainControllerMakeCommand::class,
                 DomainRouteMakeCommand::class,
-                DomainModelMakeCommand::class
+                DomainModelMakeCommand::class,
+                DomainFactoryMakeCommand::class,
+                DomainRequestMakeCommand::class
             ]);
         }
 

--- a/src/DomainRouteServiceProvider.php
+++ b/src/DomainRouteServiceProvider.php
@@ -24,16 +24,16 @@ class DomainRouteServiceProvider extends ServiceProvider
 
         foreach ($domains as $domain) {
             $dirs = array_diff(scandir(base_path('app/Domains/' . $domain)), array('.', '..'));
-            $routesDirExists = in_array('routes', $dirs);
+            $routesDirExists = in_array('Routes', $dirs);
             if (!$routesDirExists) {
                 Log::info("$domain Domain missing routes directory. Can't register routes");
                 continue;
             }
 
-            $domainRouteFiles = array_diff(scandir(base_path('app/Domains/' . $domain . '/routes')), array('.', '..'));
+            $domainRouteFiles = array_diff(scandir(base_path('app/Domains/' . $domain . '/Routes')), array('.', '..'));
             foreach ($domainRouteFiles as $file) {
                 Route::namespace($this->namespace)
-                    ->group(base_path('app/Domains/' . $domain . '/routes/' . $file));
+                    ->group(base_path('app/Domains/' . $domain . '/Routes/' . $file));
             }
         }
     }

--- a/src/DomainRouteServiceProvider.php
+++ b/src/DomainRouteServiceProvider.php
@@ -16,7 +16,6 @@ class DomainRouteServiceProvider extends ServiceProvider
 
     public function registerDomainRoutes()
     {
-
         if (!file_exists(base_path('app/Domains'))) {
             return;
         };
@@ -33,9 +32,7 @@ class DomainRouteServiceProvider extends ServiceProvider
 
             $domainRouteFiles = array_diff(scandir(base_path('app/Domains/' . $domain . '/routes')), array('.', '..'));
             foreach ($domainRouteFiles as $file) {
-                Route::prefix('api')
-                    ->middleware('api')
-                    ->namespace($this->namespace)
+                Route::namespace($this->namespace)
                     ->group(base_path('app/Domains/' . $domain . '/routes/' . $file));
             }
         }

--- a/src/DomainRouteServiceProvider.php
+++ b/src/DomainRouteServiceProvider.php
@@ -16,22 +16,27 @@ class DomainRouteServiceProvider extends ServiceProvider
 
     public function registerDomainRoutes()
     {
+
+        if (!file_exists(base_path('app/Domains'))) {
+            return;
+        };
+
         $domains = array_diff(scandir(base_path('app/Domains')), array('.', '..'));
 
-        foreach($domains as $domain) {
+        foreach ($domains as $domain) {
             $dirs = array_diff(scandir(base_path('app/Domains/' . $domain)), array('.', '..'));
             $routesDirExists = in_array('routes', $dirs);
-            if (!$routesDirExists){
+            if (!$routesDirExists) {
                 Log::info("$domain Domain missing routes directory. Can't register routes");
                 continue;
             }
 
-            $domainRouteFiles  = array_diff(scandir(base_path('app/Domains/' . $domain. '/routes')), array('.', '..'));
-            foreach($domainRouteFiles as $file){
+            $domainRouteFiles = array_diff(scandir(base_path('app/Domains/' . $domain . '/routes')), array('.', '..'));
+            foreach ($domainRouteFiles as $file) {
                 Route::prefix('api')
                     ->middleware('api')
                     ->namespace($this->namespace)
-                    ->group(base_path('app/Domains/' . $domain. '/routes/'.$file));
+                    ->group(base_path('app/Domains/' . $domain . '/routes/' . $file));
             }
         }
     }

--- a/src/stubs/cast.stub
+++ b/src/stubs/cast.stub
@@ -1,0 +1,36 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class {{ class }} implements CastsAttributes
+{
+    /**
+     * Cast the given value.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function get($model, $key, $value, $attributes)
+    {
+        return $value;
+    }
+
+    /**
+     * Prepare the given value for storage.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @param  string  $key
+     * @param  mixed  $value
+     * @param  array  $attributes
+     * @return mixed
+     */
+    public function set($model, $key, $value, $attributes)
+    {
+        return $value;
+    }
+}

--- a/src/stubs/console.stub
+++ b/src/stubs/console.stub
@@ -1,0 +1,42 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Console\Command;
+
+class {{ class }} extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = '{{ command }}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Command description';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        return 0;
+    }
+}

--- a/src/stubs/controller.api.stub
+++ b/src/stubs/controller.api.stub
@@ -1,0 +1,64 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class {{ class }} extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/src/stubs/controller.invokable.stub
+++ b/src/stubs/controller.invokable.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class {{ class }} extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request)
+    {
+        //
+    }
+}

--- a/src/stubs/controller.model.api.stub
+++ b/src/stubs/controller.model.api.stub
@@ -1,0 +1,65 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class {{ class }} extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function show({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+}

--- a/src/stubs/controller.model.stub
+++ b/src/stubs/controller.model.stub
@@ -1,0 +1,86 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class {{ class }} extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function show({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function edit({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+}

--- a/src/stubs/controller.nested.api.stub
+++ b/src/stubs/controller.nested.api.stub
@@ -1,0 +1,71 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use {{ namespacedParentModel }};
+
+class {{ class }} extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function index({{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+}

--- a/src/stubs/controller.nested.stub
+++ b/src/stubs/controller.nested.stub
@@ -1,0 +1,94 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use {{ namespacedParentModel }};
+
+class {{ class }} extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function index({{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function create({{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request, {{ parentModel }} ${{ parentModelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function show({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function edit({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, {{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \{{ namespacedParentModel }}  ${{ parentModelVariable }}
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy({{ parentModel }} ${{ parentModelVariable }}, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+}

--- a/src/stubs/controller.plain.stub
+++ b/src/stubs/controller.plain.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class {{ class }} extends Controller
+{
+    //
+}

--- a/src/stubs/controller.stub
+++ b/src/stubs/controller.stub
@@ -1,0 +1,85 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ rootNamespace }}Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+class {{ class }} extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/src/stubs/exception-render-report.stub
+++ b/src/stubs/exception-render-report.stub
@@ -1,0 +1,29 @@
+<?php
+
+namespace {{ namespace }};
+
+use Exception;
+
+class {{ class }} extends Exception
+{
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report()
+    {
+        //
+    }
+
+    /**
+     * Render the exception as an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        //
+    }
+}

--- a/src/stubs/exception-render.stub
+++ b/src/stubs/exception-render.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use Exception;
+
+class {{ class }} extends Exception
+{
+    /**
+     * Render the exception as an HTTP response.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function render($request)
+    {
+        //
+    }
+}

--- a/src/stubs/exception-report.stub
+++ b/src/stubs/exception-report.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+use Exception;
+
+class {{ class }} extends Exception
+{
+    /**
+     * Report the exception.
+     *
+     * @return bool|null
+     */
+    public function report()
+    {
+        //
+    }
+}

--- a/src/stubs/exception.stub
+++ b/src/stubs/exception.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace {{ namespace }};
+
+use Exception;
+
+class {{ class }} extends Exception
+{
+    //
+}

--- a/src/stubs/factory.stub
+++ b/src/stubs/factory.stub
@@ -1,0 +1,28 @@
+<?php
+
+namespace {{ factoryNamespace }};
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use {{ namespacedModel }};
+
+class {{ factory }}Factory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = {{ model }}::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/stubs/job.queued.stub
+++ b/src/stubs/job.queued.stub
@@ -1,0 +1,35 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class {{ class }} implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        //
+    }
+}

--- a/src/stubs/job.stub
+++ b/src/stubs/job.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Foundation\Bus\Dispatchable;
+
+class {{ class }}
+{
+    use Dispatchable;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        //
+    }
+}

--- a/src/stubs/middleware.stub
+++ b/src/stubs/middleware.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace {{ namespace }};
+
+use Closure;
+use Illuminate\Http\Request;
+
+class {{ class }}
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        return $next($request);
+    }
+}

--- a/src/stubs/migration.create.stub
+++ b/src/stubs/migration.create.stub
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class {{ class }} extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('{{ table }}', function (Blueprint $table) {
+            $table->uuid()->primary;
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('{{ table }}');
+    }
+}

--- a/src/stubs/migration.stub
+++ b/src/stubs/migration.stub
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class {{ class }} extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/src/stubs/migration.update.stub
+++ b/src/stubs/migration.update.stub
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class {{ class }} extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/src/stubs/model.pivot.stub
+++ b/src/stubs/model.pivot.stub
@@ -1,0 +1,10 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class {{ class }} extends Pivot
+{
+    //
+}

--- a/src/stubs/model.stub
+++ b/src/stubs/model.stub
@@ -1,0 +1,12 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Traits\hasUuid;
+
+class {{ class }} extends Model
+{
+    use HasFactory, hasUuid;
+}

--- a/src/stubs/observer.plain.stub
+++ b/src/stubs/observer.plain.stub
@@ -1,0 +1,8 @@
+<?php
+
+namespace {{ namespace }};
+
+class {{ class }}
+{
+    //
+}

--- a/src/stubs/observer.stub
+++ b/src/stubs/observer.stub
@@ -1,0 +1,63 @@
+<?php
+
+namespace {{ namespace }};
+
+use {{ namespacedModel }};
+
+class {{ class }}
+{
+    /**
+     * Handle the {{ model }} "created" event.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return void
+     */
+    public function created({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Handle the {{ model }} "updated" event.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return void
+     */
+    public function updated({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Handle the {{ model }} "deleted" event.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return void
+     */
+    public function deleted({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Handle the {{ model }} "restored" event.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return void
+     */
+    public function restored({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Handle the {{ model }} "force deleted" event.
+     *
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return void
+     */
+    public function forceDeleted({{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+}

--- a/src/stubs/policy.plain.stub
+++ b/src/stubs/policy.plain.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use {{ namespacedUserModel }};
+
+class {{ class }}
+{
+    use HandlesAuthorization;
+
+    /**
+     * Create a new policy instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+}

--- a/src/stubs/policy.stub
+++ b/src/stubs/policy.stub
@@ -1,0 +1,94 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use {{ namespacedModel }};
+use {{ namespacedUserModel }};
+
+class {{ class }}
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     *
+     * @param  \{{ namespacedUserModel }}  $user
+     * @return mixed
+     */
+    public function viewAny({{ user }} $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return mixed
+     */
+    public function view({{ user }} $user, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can create models.
+     *
+     * @param  \{{ namespacedUserModel }}  $user
+     * @return mixed
+     */
+    public function create({{ user }} $user)
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     *
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return mixed
+     */
+    public function update({{ user }} $user, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     *
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return mixed
+     */
+    public function delete({{ user }} $user, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     *
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return mixed
+     */
+    public function restore({{ user }} $user, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     *
+     * @param  \{{ namespacedUserModel }}  $user
+     * @param  \{{ namespacedModel }}  ${{ modelVariable }}
+     * @return mixed
+     */
+    public function forceDelete({{ user }} $user, {{ model }} ${{ modelVariable }})
+    {
+        //
+    }
+}

--- a/src/stubs/repository.stub
+++ b/src/stubs/repository.stub
@@ -1,0 +1,54 @@
+<?php
+
+namespace {{ namespace }};
+
+use App\Domains\{{ domain }}\Models\{{ model }};
+use Illuminate\Database\Eloquent\Collection;
+
+class {{ class }}
+{
+    /**
+     * @return Collection<{{ model }}>
+     */
+    public function getAll(): Collection
+    {
+        return {{ model }}::all();
+    }
+
+    /**
+     * @param int $id {{ model }} id
+     * @return {{ model }}
+     */
+    public function getById($id): {{ model }}
+    {
+        return {{ model }}::findOrFail($id);
+    }
+
+    /**
+     * @param int $id {{ model }} id
+     * @return int
+     */
+    public function delete($id): int
+    {
+        return {{ model }}::destroy($id);
+    }
+
+    /**
+     * @param array $details What should the model consists of
+     * @return {{ model }}
+     */
+    public function create(array $Details): TestModel
+    {
+        return {{ model }}::create($Details);
+    }
+
+    /**
+     * @param int $id {{ model }} id
+     * @param array $newDetails What should the model consists of
+     * @return {{ model }}
+     */
+    public function update($id, array $newDetails): bool
+    {
+        return {{ model }}::whereId($id)->update($newDetails);
+    }
+}

--- a/src/stubs/request.stub
+++ b/src/stubs/request.stub
@@ -1,0 +1,30 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class {{ class }} extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/src/stubs/resource-collection.stub
+++ b/src/stubs/resource-collection.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Resources\Json\ResourceCollection;
+
+class {{ class }} extends ResourceCollection
+{
+    /**
+     * Transform the resource collection into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/src/stubs/resource.stub
+++ b/src/stubs/resource.stub
@@ -1,0 +1,19 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class {{ class }} extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array
+     */
+    public function toArray($request)
+    {
+        return parent::toArray($request);
+    }
+}

--- a/src/stubs/routes-api-with-controller.stub
+++ b/src/stubs/routes-api-with-controller.stub
@@ -1,0 +1,10 @@
+<?php
+
+use App\Domains\{{DummyDomain}}\Http\Controllers\{{DummyController}};
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('api')->middleware('api')->prefix('{{DummyPrefix}}')->group(function () {
+    Route::resource('/', {{DummyController}}::class);
+});
+
+

--- a/src/stubs/routes-with-controller.stub
+++ b/src/stubs/routes-with-controller.stub
@@ -1,0 +1,9 @@
+<?php
+
+use App\Domains\{{DummyDomain}}\Http\Controllers\{{DummyController}};
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('{{DummyPrefix}}')->group(function () {
+    Route::resource('/', {{DummyController}}::class);
+
+});

--- a/src/stubs/routes.stub
+++ b/src/stubs/routes.stub
@@ -1,0 +1,9 @@
+<?php
+
+use App\Domains\{{DummyDomain}}\Http\Controllers\{{DummyController}};
+use Illuminate\Support\Facades\Route;
+
+Route::prefix('{{DummyPrefix}}')->group(function () {
+    Route::get('/', [{{DummyController}}::class, 'index']);
+    Route::post('/', [{{DummyController}}::class, 'store']);
+});

--- a/src/stubs/routes.stub
+++ b/src/stubs/routes.stub
@@ -1,9 +1,9 @@
 <?php
 
-use App\Domains\{{DummyDomain}}\Http\Controllers\{{DummyController}};
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('{{DummyPrefix}}')->group(function () {
-    Route::get('/', [{{DummyController}}::class, 'index']);
-    Route::post('/', [{{DummyController}}::class, 'store']);
+       Route::get('/', function(){
+           return 'test';
+       });
 });

--- a/src/stubs/rule.stub
+++ b/src/stubs/rule.stub
@@ -1,0 +1,40 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Contracts\Validation\Rule;
+
+class {{ class }} implements Rule
+{
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        //
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return 'The validation error message.';
+    }
+}

--- a/src/stubs/seeder.stub
+++ b/src/stubs/seeder.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class {{ class }} extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        //
+    }
+}

--- a/src/stubs/service.stub
+++ b/src/stubs/service.stub
@@ -1,0 +1,11 @@
+<?php
+
+namespace {{ namespace }};
+
+
+class {{ class }}
+{
+    public function handle()
+    {
+    }
+}

--- a/src/stubs/test.stub
+++ b/src/stubs/test.stub
@@ -1,0 +1,22 @@
+<?php
+
+namespace {{ namespace }};
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Tests\TestCase;
+
+class {{ class }} extends TestCase
+{
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testExample()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/src/stubs/test.unit.stub
+++ b/src/stubs/test.unit.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace {{ namespace }};
+
+use PHPUnit\Framework\TestCase;
+
+class {{ class }} extends TestCase
+{
+    /**
+     * A basic unit test example.
+     *
+     * @return void
+     */
+    public function testExample()
+    {
+        $this->assertTrue(true);
+    }
+}


### PR DESCRIPTION
- Generator for repositories, services, exceptions and job added
- Fixed error with generating models with migrations `domain:make:model {domain} {name} -m`
- Fixed problem with stub not found for _model_ when stubs weren't published
- "routes" capitalized to "Routes" for consistency
- Updated readme and changelog  

I'm not really happy about how the DomainRepositoryMakeCommand turned out, however it works
