### PR TITLE
Fix Domain scanning by making sure $domain is a directory

### DIFF
--- a/src/DomainRouteServiceProvider.php
+++ b/src/DomainRouteServiceProvider.php
@@ -23,6 +23,10 @@ class DomainRouteServiceProvider extends ServiceProvider
         $domains = array_diff(scandir(base_path('app/Domains')), array('.', '..'));
 
         foreach ($domains as $domain) {
+            if (!is_dir($domain)) {
+                continue;
+            }
+            
             $dirs = array_diff(scandir(base_path('app/Domains/' . $domain)), array('.', '..'));
             $routesDirExists = in_array('routes', $dirs);
             if (!$routesDirExists) {

--- a/src/ViewProvider.php
+++ b/src/ViewProvider.php
@@ -41,6 +41,10 @@ class ViewProvider extends ServiceProvider
         $domains = array_diff(scandir(base_path('app/Domains')), array('.', '..'));
 
         foreach ($domains as $domain) {
+            if (!is_dir($domain)) {
+                continue;
+            }
+            
             $dirs = array_diff(scandir(base_path('app/Domains/' . $domain)), array('.', '..'));
             $resourcesDirExists = in_array('resources', $dirs);
             if (!$resourcesDirExists) {

--- a/src/helpers/DomainPathsProvider.php
+++ b/src/helpers/DomainPathsProvider.php
@@ -14,6 +14,10 @@ class DomainPathsProvider
 
     $domainPaths = [];
     foreach($domains as $domain) {
+      if (!is_dir($domain)) {
+        continue;
+      }
+
       $domainPaths[] = 'app/Domains/' . $domain;
     }
 


### PR DESCRIPTION
Fixes issue phpsquad/domain-maker#6 where package breaks when scanning `app/Domains` directory that contains a file.

I decided to go with `is_dir()` so that we don't have to change the flow of the looping used.